### PR TITLE
Replace call to jax.tree_leaves

### DIFF
--- a/kheperax/utils/tree_utils.py
+++ b/kheperax/utils/tree_utils.py
@@ -3,7 +3,7 @@ from chex import ArrayTree
 
 
 def get_batch_size(tree: ArrayTree) -> int:
-    batch_size = jax.tree_leaves(tree)[0].shape[0]
+    batch_size = jax.tree_util.tree_leaves(tree)[0].shape[0]
     return batch_size
 
 


### PR DESCRIPTION
Hi @Lookatator, I ran into a deprecated call to `jax.tree_leaves` when running Kheperax with jax 0.6.0. Here is a PR that updates it to call `jax.tree_util.tree_leaves`, which doesn't break in 0.6.0.